### PR TITLE
Make GitHub detect *.fs as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.fs linguist-language=Forth linguist-documentation=false


### PR DESCRIPTION
Hej!

Please merge this, if you'd like GitHub to detect all three `.fs` files as Forth.

Tack!
